### PR TITLE
Add excluded topics setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,4 @@ en:
   site_settings:
     sitemap_enabled: 'Enable sitemap.xml'
     sitemap_topics_per_page: 'Number of topics shown on the sitemap page.'
+    sitemap_excluded_topics_pattern: 'exclude topics by a regex match on title.'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,3 +3,7 @@ plugins:
     default: true
   sitemap_topics_per_page:
     default: 10000
+  sitemap_excluded_topics_pattern:
+    default: ''
+    validator: RegexSettingValidator
+    

--- a/plugin.rb
+++ b/plugin.rb
@@ -28,6 +28,12 @@ after_initialize do
     def topics_query(since = nil)
       category_ids = Category.where(read_restricted: false).pluck(:id)
       query = Topic.where(category_id: category_ids, visible: true)
+      
+      excluded_topics_pattern = SiteSetting.sitemap_excluded_topics_pattern
+      if excluded_topics_pattern.present?
+        query = query.where("title !~ ?", excluded_topics_pattern)
+      end
+      
       if since
         query = query.where('last_posted_at > ?', since)
         query = query.order(last_posted_at: :desc)


### PR DESCRIPTION
Adds a site setting that lets you exclude topics from the sitemap via a regex filter on the title.