### PR TITLE
Fixed broken link for instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-Follow [the usual installation instructions](https://meta.discourse.org/t/advanced-troubleshooting-with-docker/15927#Example:%20Install%20a%20plugin).
+Follow [the usual installation instructions](https://meta.discourse.org/t/install-plugins-in-discourse/19157).
 
 On a non-Docker install do `bundle exec rake plugin:install repo=http://github.com/discourse/discourse-sitemap`. There is no need for asset precompilation.
 


### PR DESCRIPTION
Thanks for your work on this plugin! I'm just submitting a simple fix for a broken link in the README.md file. It leads to a 404 now.

I updated the link to the official "howto"/"admins" on meta.discourse.org