### PR TITLE
FIX: Compute number of pages correctly

### DIFF
--- a/app/views/discourse_sitemap/sitemap/default.erb
+++ b/app/views/discourse_sitemap/sitemap/default.erb
@@ -11,10 +11,9 @@
     <%-
         url = "#{Discourse.base_url}/t/#{topic[1]}/#{topic[0]}"
         if topic[4]
-          page = ((topic[4]+1) / TopicView.chunk_size) + 1
-          if page > 1
-            url += "?page=#{page}"
-          end
+          page = topic[4] / TopicView.chunk_size
+          page += 1 if topic[4] % TopicView.chunk_size > 0
+          url += "?page=#{page}" if page > 1
         end
     -%>
         <loc><%= url %></loc>


### PR DESCRIPTION
There were multiple off-by-one errors which counted as two pages of 20
posts even when there were only 19 posts.